### PR TITLE
Change control card rationale button label from 'Why' to '?'

### DIFF
--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -129,7 +129,7 @@ export function QuestionCard({
         <button
           type="button"
           onClick={() => setShowHelp((value) => !value)}
-          className={`rounded-[6px] border px-2.5 py-1.5 font-mono text-[11px] font-semibold uppercase tracking-[0.08em] transition-colors ${
+          className={`rounded-[6px] border px-2.5 py-1.5 text-[11px] font-semibold uppercase transition-colors ${
             showHelp
               ? "border-accent bg-accent-subtle text-accent"
               : "border-border bg-surface text-text-muted hover:border-accent hover:text-accent"
@@ -137,7 +137,7 @@ export function QuestionCard({
           aria-expanded={showHelp}
           aria-label="Toggle rationale and examples"
         >
-          Why
+          ?
         </button>
       </div>
 

--- a/src/components/__tests__/QuestionCard.test.tsx
+++ b/src/components/__tests__/QuestionCard.test.tsx
@@ -50,6 +50,11 @@ describe("QuestionCard", () => {
     expect(html).not.toContain("Optional notes");
   });
 
+  it("renders the rationale toggle button with '?' label", () => {
+    const html = renderCard();
+    expect(html).toContain("?");
+  });
+
   it("shows note-only draft responses on initial render", () => {
     const html = renderCard({
       notes: "Draft evidence",


### PR DESCRIPTION
Closes #7

## Summary
- Replaces the `Why` button text on control cards with `?` for a cleaner, icon-like appearance
- Removes `font-mono` and `tracking-[0.08em]` from the button className (no longer needed)
- Adds a regression test asserting the button renders with `?`

## Test plan
- [ ] All 67 tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] Visual check: control card shows `?` button instead of `WHY`