### PR TITLE
Extract shield SVG into shared ShieldIcon component

### DIFF
--- a/src/components/Assessment.tsx
+++ b/src/components/Assessment.tsx
@@ -19,6 +19,7 @@ import {
 import type { AnswerStatus, AssessmentState, ControlBank } from "../lib/types.ts";
 import controlData from "../identity-controls-v2.1.json";
 import { AssessmentControls } from "./AssessmentControls.tsx";
+import { ShieldIcon } from "./ShieldIcon.tsx";
 import { QuestionCard } from "./QuestionCard.tsx";
 import { ResultsPanel } from "./ResultsPanel.tsx";
 import { SectionNav } from "./SectionNav.tsx";
@@ -166,20 +167,7 @@ export function Assessment({ isDark, onBack, onToggleTheme }: AssessmentProps) {
             </button>
             {isDesktop ? (
               <div className="flex items-center gap-[10px]">
-                <svg
-                  width="18"
-                  height="18"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  className="shrink-0 text-accent"
-                  aria-hidden="true"
-                >
-                  <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z" />
-                </svg>
+                <ShieldIcon />
                 <span className="font-mono text-[14px] font-semibold uppercase tracking-[0.08em] text-text-primary">
                   Identity Posture
                 </span>

--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { ShieldIcon } from "./ShieldIcon.tsx";
 import { ThemeToggle } from "./ThemeToggle.tsx";
 
 interface LandingProps {
@@ -35,20 +36,7 @@ export function Landing({ isDark, onStart, onToggleTheme }: LandingProps) {
       <nav className="border-b border-border bg-surface">
         <div className="mx-auto flex h-14 w-full max-w-7xl items-center justify-between gap-6 px-6 md:px-10">
           <div className="flex items-center gap-[10px]">
-            <svg
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className="shrink-0 text-accent"
-              aria-hidden="true"
-            >
-              <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z" />
-            </svg>
+            <ShieldIcon />
             <span className="font-mono text-[14px] font-semibold uppercase tracking-[0.08em] text-text-primary">
               Identity Posture
             </span>

--- a/src/components/ShieldIcon.tsx
+++ b/src/components/ShieldIcon.tsx
@@ -1,0 +1,18 @@
+export function ShieldIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0 text-accent"
+      aria-hidden="true"
+    >
+      <path d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z" />
+    </svg>
+  );
+}

--- a/src/components/__tests__/ShieldIcon.test.tsx
+++ b/src/components/__tests__/ShieldIcon.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ShieldIcon } from "../ShieldIcon.tsx";
+
+describe("ShieldIcon", () => {
+  it("renders an svg element with aria-hidden", () => {
+    const html = renderToStaticMarkup(<ShieldIcon />);
+    expect(html).toContain("<svg");
+    expect(html).toContain('aria-hidden="true"');
+  });
+
+  it("renders with the correct dimensions", () => {
+    const html = renderToStaticMarkup(<ShieldIcon />);
+    expect(html).toContain('width="18"');
+    expect(html).toContain('height="18"');
+  });
+
+  it("renders the shield path", () => {
+    const html = renderToStaticMarkup(<ShieldIcon />);
+    expect(html).toContain("M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z");
+  });
+
+  it("applies the correct classes", () => {
+    const html = renderToStaticMarkup(<ShieldIcon />);
+    expect(html).toContain("shrink-0");
+    expect(html).toContain("text-accent");
+  });
+});


### PR DESCRIPTION
Resolves #15

Extracts the duplicate shield SVG from `Landing.tsx` and `Assessment.tsx` into a shared `<ShieldIcon />` component. Adds 4 unit tests covering dimensions, path, classes, and accessibility attribute.