### PR TITLE
Polish launch metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Identity Security Posture Review
 
-Identity Security Posture Review is a browser-based self-assessment for workforce IAM controls. It helps security and identity teams score coverage across the identity domains most often involved in credential-driven incidents, identify immediate exposure, and generate a concise summary for leadership.
+Identity Security Posture Review is a self-assessment for workforce IAM controls. It helps security and identity teams score coverage across the identity domains most often involved in credential-driven incidents, identify immediate exposure, and generate a concise summary for leadership.
 
 Live app: [identity-posture.nalegave.com](https://identity-posture.nalegave.com)
 
@@ -58,4 +58,4 @@ npm run build
 
 - The app is designed for static hosting.
 - Assessment data remains in the browser unless the user exports it.
-- The repository includes a baseline Content Security Policy in [`index.html`](/Users/sidnalegave-mini/Projects/web/identity-posture/index.html), but production deployments should still send security headers at the HTTP layer.
+- The repository injects a baseline Content Security Policy at build time from [`vite.config.ts`](/Users/sidnalegave-mini/Projects/web/identity-posture/vite.config.ts), but production deployments should still send security headers at the HTTP layer.

--- a/index.html
+++ b/index.html
@@ -4,10 +4,29 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Workforce IAM self-assessment for scoring identity control coverage, prioritizing gaps, and generating a leadership-ready posture summary."
+    />
+    <meta name="theme-color" content="#f5f7fb" />
+    <link rel="canonical" href="https://identity-posture.nalegave.com" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Identity Security Posture Review" />
+    <meta
+      property="og:description"
+      content="Score identity control coverage, prioritize gaps, and generate a concise posture summary for leadership."
+    />
+    <meta property="og:url" content="https://identity-posture.nalegave.com" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Identity Security Posture Review" />
+    <meta
+      name="twitter:description"
+      content="Score identity control coverage, prioritize gaps, and generate a concise posture summary for leadership."
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Sora:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
-    <title>Identity Posture</title>
+    <title>Identity Security Posture Review</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Identity Posture">
-  <rect width="64" height="64" rx="12" fill="#1A55C0" />
-  <circle cx="32" cy="24" r="9" fill="#FFFFFF" />
+  <rect width="64" height="64" rx="12" fill="#F5F7FB" />
   <path
-    d="M18 48c0-7.732 6.268-14 14-14s14 6.268 14 14"
+    d="M32 8 13 16.444V29.111C13 40.815 21.107 51.76 32 54.667c10.893-2.907 19-13.852 19-25.556V16.444L32 8Z"
     fill="none"
-    stroke="#FFFFFF"
-    stroke-width="8"
+    stroke="#1A55C0"
+    stroke-width="5.333"
     stroke-linecap="round"
+    stroke-linejoin="round"
   />
 </svg>


### PR DESCRIPTION
## Summary
- add launch-ready page metadata for link previews and search snippets
- correct the README note about where the baseline CSP is defined
- replace the favicon with the shield mark used in the app nav

## Verification
- npm run format
- npm run lint
- npm test
- npm run build