### PR TITLE
feat: improve Top Risks framing in copy summary

### DIFF
--- a/src/lib/__tests__/export.test.ts
+++ b/src/lib/__tests__/export.test.ts
@@ -66,7 +66,22 @@ describe("buildCopySummary", () => {
     expect(result).toContain("Privileged Access (41%) represents");
     expect(result).toContain("Authentication & MFA: 70%");
     expect(result).toContain("Privileged Access: N/A");
-    expect(result).toContain("- Least Privilege");
+    expect(result).toContain("- No Least Privilege");
+  });
+
+  it("prefixes gap risks with 'No' and partial risks with 'Partial:'", () => {
+    const makeRisk = (title: string, status: "gap" | "partial"): TopRisk => ({
+      control: { id: title, section_id: "auth", title, tier: "foundational", weight: 5, order: 1, prompt: "", rationale: "", next_step: "" },
+      status,
+    });
+
+    const result = buildCopySummary(50, "Partial Coverage", "", [], [
+      makeRisk("Phishing-Resistant MFA", "gap"),
+      makeRisk("Step-Up Authentication", "partial"),
+    ]);
+
+    expect(result).toContain("- No Phishing-Resistant MFA");
+    expect(result).toContain("- Partial: Step-Up Authentication");
   });
 
   it("limits top risks to 3", () => {
@@ -87,7 +102,7 @@ describe("buildCopySummary", () => {
     }));
 
     const result = buildCopySummary(30, "High Exposure", "test", sectionScores, topRisks);
-    const riskLines = result.split("\n").filter((l) => l.startsWith("- Risk"));
+    const riskLines = result.split("\n").filter((l) => l.startsWith("- No Risk"));
     expect(riskLines).toHaveLength(3);
   });
 

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -146,7 +146,11 @@ export function buildCopySummary(
   lines.push("");
   lines.push("Top Risks");
   for (const risk of topRisks.slice(0, 3)) {
-    lines.push(`- ${risk.control.title}`);
+    const label =
+      risk.status === "gap"
+        ? `No ${risk.control.title}`
+        : `Partial: ${risk.control.title}`;
+    lines.push(`- ${label}`);
   }
   return lines.join("\n");
 }


### PR DESCRIPTION
Closes #39

## Summary
- Gap risks now read as `No <title>` (e.g. "No Dedicated Administrative Accounts")
- Partial risks now read as `Partial: <title>` (e.g. "Partial: Step-Up Authentication for Sensitive Actions")
- Updated existing tests and added a new test covering both status prefixes

## Test plan
- [x] Complete an assessment with at least one gap and one partial control
- [x] Click "Copy Executive Summary"
- [x] Verify Top Risks lines are prefixed with "No" or "Partial:" instead of plain titles