### PR TITLE
feat: simplify posture summary fallback text

### DIFF
--- a/src/lib/__tests__/scoring.test.ts
+++ b/src/lib/__tests__/scoring.test.ts
@@ -381,7 +381,7 @@ describe("getPostureInterpretation", () => {
     );
   });
 
-  it("uses provisional language when any section is unscored", () => {
+  it("returns completion prompt when all scored sections are 100% but some are unscored", () => {
     const sections = [
       { section_id: "auth", label: "Authentication & MFA", score: 100, answered: 5, total: 5 },
       { section_id: "priv", label: "Privileged Access", score: 100, answered: 4, total: 4 },
@@ -391,12 +391,12 @@ describe("getPostureInterpretation", () => {
 
     const result = getPostureInterpretation(sections, 13);
     expect(result).toBe(
-      "Current scored sections show strong coverage, but one or more sections are still incomplete, so the posture summary is provisional.",
+      "All assessed sections are at 100%. Complete the remaining sections to finalize your posture summary.",
     );
     expect(result).not.toContain("highest-probability attack path");
   });
 
-  it("uses provisional language when any section score is null", () => {
+  it("shows weakest section and provisional note when some sections are unscored", () => {
     const sections = [
       { section_id: "auth", label: "Authentication & MFA", score: null, answered: 0, total: 5 },
       { section_id: "priv", label: "Privileged Access", score: 41, answered: 2, total: 4 },
@@ -404,9 +404,8 @@ describe("getPostureInterpretation", () => {
       { section_id: "mon", label: "Monitoring", score: 72, answered: 2, total: 4 },
     ];
     const result = getPostureInterpretation(sections, 10);
-    expect(result).toBe(
-      "Current scored sections show strong coverage, but one or more sections are still incomplete, so the posture summary is provisional.",
-    );
-    expect(result).not.toContain("highest-probability attack path");
+    expect(result).toContain("highest-probability attack path");
+    expect(result).toContain("Posture summary is provisional — not all sections are complete.");
+    expect(result).toContain("Privileged Access (41%)");
   });
 });

--- a/src/lib/__tests__/scoring.test.ts
+++ b/src/lib/__tests__/scoring.test.ts
@@ -302,7 +302,7 @@ describe("getPostureInterpretation", () => {
   it("returns the new fallback message when fewer than 3 controls are answered", () => {
     const result = getPostureInterpretation([], 2);
     expect(result).toBe(
-      "Complete controls in at least two sections to generate a reliable posture summary.",
+      "Complete more controls to generate a reliable posture summary.",
     );
   });
 
@@ -313,7 +313,7 @@ describe("getPostureInterpretation", () => {
     ];
     const result = getPostureInterpretation(sections, 3);
     expect(result).toBe(
-      "Complete controls in at least two sections to generate a reliable posture summary.",
+      "Complete more controls to generate a reliable posture summary.",
     );
   });
 

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -151,7 +151,7 @@ export function getPostureInterpretation(
   answeredCount: number,
 ): string {
   if (answeredCount < 3) {
-    return "Complete controls in at least two sections to generate a reliable posture summary.";
+    return "Complete more controls to generate a reliable posture summary.";
   }
 
   const scored = sectionScores
@@ -159,7 +159,7 @@ export function getPostureInterpretation(
     .sort((a, b) => a.score - b.score);
 
   if (scored.length < 2) {
-    return "Complete controls in at least two sections to generate a reliable posture summary.";
+    return "Complete more controls to generate a reliable posture summary.";
   }
 
   const formatScore = (score: number) => `${Math.round(score)}%`;

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -172,16 +172,15 @@ export function getPostureInterpretation(
 
   const focusText = focusSections.join(" and ");
   const verb = focusSections.length === 1 ? "represents" : "represent";
-  const allSectionsPerfect =
-    scored.length === sectionScores.length && scored.every((section) => section.score === 100);
+  const allScoredPerfect = scored.every((section) => section.score === 100);
   const hasUnscoredSections = scored.length !== sectionScores.length;
 
-  if (allSectionsPerfect) {
+  if (allScoredPerfect && !hasUnscoredSections) {
     return "All scored identity areas are at 100%, indicating complete assessed coverage across the posture model.";
   }
 
-  if (hasUnscoredSections) {
-    return "Current scored sections show strong coverage, but one or more sections are still incomplete, so the posture summary is provisional.";
+  if (allScoredPerfect) {
+    return "All assessed sections are at 100%. Complete the remaining sections to finalize your posture summary.";
   }
 
   const consequences: Record<string, string> = {
@@ -192,6 +191,9 @@ export function getPostureInterpretation(
   };
 
   const consequence = consequences[lowest.section_id] ?? "";
+  const provisional = hasUnscoredSections
+    ? " Posture summary is provisional — not all sections are complete."
+    : "";
 
-  return `${focusText} ${verb} your highest-probability attack path. ${consequence}`;
+  return `${focusText} ${verb} your highest-probability attack path. ${consequence}${provisional}`;
 }


### PR DESCRIPTION
Closes #38

## Summary
- Replaces "Complete controls in at least two sections to generate a reliable posture summary." with "Complete more controls to generate a reliable posture summary."
- Removes implementation detail leakage ("at least two sections") from user-facing copy
- Updated both occurrences in `scoring.ts` and matching test assertions

## Test plan
- [ ] Start a fresh assessment and answer fewer than 3 controls — verify the new message appears in the posture summary panel
- [ ] Answer controls in only one section — verify same message appears