### PR TITLE
fix: allow Cloudflare analytics origins in CSP

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 
 const baselineCsp =
-  "default-src 'self'; script-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; form-action 'self'";
+  "default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://cloudflareinsights.com; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; form-action 'self'";
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "vite";
 
 const baselineCsp =
-  "default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; connect-src 'self' https://cloudflareinsights.com; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; form-action 'self'";
+  "default-src 'self'; script-src 'self' https://static.cloudflareinsights.com 'sha256-ZswfTY7H35rbv8WC7NXBoiC7WNu86vSzCDChNWwZZDM='; connect-src 'self' https://cloudflareinsights.com; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; form-action 'self'";
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Closes #35

## Summary
- Adds `https://static.cloudflareinsights.com` to `script-src` so Cloudflare Pages' auto-injected beacon script is allowed
- Adds `https://cloudflareinsights.com` to `connect-src` so the beacon can report data

No changes to `index.html` — Cloudflare Pages injects the snippet automatically on deployment.

## Test plan
- [x] Merge and deploy to Cloudflare Pages
- [x] Open the site and check browser console — no CSP errors for analytics
- [x] Verify a pageview appears in Cloudflare Web Analytics dashboard